### PR TITLE
chore(ds): add bundle analysis — esbuild metafile + rollup-plugin-visualizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3784,6 +3784,32 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "dev": true,
@@ -3826,6 +3852,22 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bundle-require": {
@@ -3934,6 +3976,21 @@
     "node_modules/client-only": {
       "version": "0.0.1",
       "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -4158,6 +4215,49 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "license": "MIT",
@@ -4192,6 +4292,13 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
@@ -4282,6 +4389,16 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -4641,6 +4758,29 @@
         }
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "license": "MIT",
@@ -4843,12 +4983,60 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-hexadecimal": {
       "version": "2.0.1",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -4869,6 +5057,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jiti": {
@@ -6334,6 +6538,27 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -6487,6 +6712,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/property-information": {
@@ -6993,6 +7231,50 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
+      "integrity": "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^11.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "license": "MIT"
@@ -7119,6 +7401,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "license": "MIT",
@@ -7129,6 +7429,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/style-to-js": {
@@ -7663,6 +7979,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -7683,6 +8017,61 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/zod": {
@@ -7718,7 +8107,7 @@
     },
     "packages/unified-ui": {
       "name": "@work-rjkashyap/unified-ui",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.1",
@@ -7739,6 +8128,7 @@
         "framer-motion": "^12.34.3",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
+        "rollup-plugin-visualizer": "^7.0.1",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3"
       },
@@ -7754,12 +8144,104 @@
         "framer-motion": ">=12.0.0"
       },
       "peerDependencies": {
+        "@radix-ui/primitive": ">=1.0.0",
+        "@radix-ui/react-compose-refs": ">=1.0.0",
+        "@radix-ui/react-context": ">=1.0.0",
+        "@radix-ui/react-dismissable-layer": ">=1.0.0",
+        "@radix-ui/react-popper": ">=1.0.0",
+        "@radix-ui/react-portal": ">=1.0.0",
+        "@radix-ui/react-presence": ">=1.0.0",
+        "@radix-ui/react-primitive": ">=1.0.0",
+        "@radix-ui/react-slot": ">=1.0.0",
+        "@radix-ui/react-tooltip": ">=1.0.0",
+        "@radix-ui/react-use-callback-ref": ">=1.0.0",
+        "@radix-ui/react-use-controllable-state": ">=1.0.0",
+        "@radix-ui/react-use-effect-event": ">=0.0.1",
+        "@radix-ui/react-use-layout-effect": ">=1.0.0",
+        "@radix-ui/react-use-size": ">=1.0.0",
+        "@radix-ui/react-visually-hidden": ">=1.0.0",
+        "class-variance-authority": ">=0.7.0",
+        "clsx": ">=2.0.0",
+        "radix-ui": ">=1.0.0",
         "react": ">=19.0.0",
         "react-dom": ">=19.0.0",
-        "tailwindcss": ">=4.0.0"
+        "react-resizable-panels": ">=4.0.0",
+        "sonner": ">=2.0.0",
+        "tailwind-merge": ">=3.0.0",
+        "tailwindcss": ">=4.0.0",
+        "vaul": ">=1.0.0"
       },
       "peerDependenciesMeta": {
+        "@radix-ui/primitive": {
+          "optional": true
+        },
+        "@radix-ui/react-compose-refs": {
+          "optional": true
+        },
+        "@radix-ui/react-context": {
+          "optional": true
+        },
+        "@radix-ui/react-dismissable-layer": {
+          "optional": true
+        },
+        "@radix-ui/react-popper": {
+          "optional": true
+        },
+        "@radix-ui/react-portal": {
+          "optional": true
+        },
+        "@radix-ui/react-presence": {
+          "optional": true
+        },
+        "@radix-ui/react-primitive": {
+          "optional": true
+        },
+        "@radix-ui/react-slot": {
+          "optional": true
+        },
+        "@radix-ui/react-tooltip": {
+          "optional": true
+        },
+        "@radix-ui/react-use-callback-ref": {
+          "optional": true
+        },
+        "@radix-ui/react-use-controllable-state": {
+          "optional": true
+        },
+        "@radix-ui/react-use-effect-event": {
+          "optional": true
+        },
+        "@radix-ui/react-use-layout-effect": {
+          "optional": true
+        },
+        "@radix-ui/react-use-size": {
+          "optional": true
+        },
+        "@radix-ui/react-visually-hidden": {
+          "optional": true
+        },
+        "class-variance-authority": {
+          "optional": false
+        },
+        "clsx": {
+          "optional": false
+        },
+        "radix-ui": {
+          "optional": false
+        },
+        "react-resizable-panels": {
+          "optional": true
+        },
+        "sonner": {
+          "optional": true
+        },
+        "tailwind-merge": {
+          "optional": false
+        },
         "tailwindcss": {
+          "optional": true
+        },
+        "vaul": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "analyze": "NODE_OPTIONS='--max-old-space-size=8192' sh -c 'npm run build:registry && ANALYZE=true OPEN_ANALYZER=true next build'",
     "prepare": "git config core.hooksPath .githooks && chmod +x .githooks/pre-commit .githooks/pre-push",
     "build:ds": "npm run build --workspace=@work-rjkashyap/unified-ui",
+    "analyze:ds": "npm run analyze --workspace=@work-rjkashyap/unified-ui",
     "build:registry": "node scripts/build-registry.mjs",
     "pack:ds": "npm run build:ds && cd packages/unified-ui && npm pack --pack-destination ../../",
     "release": "npm publish --workspace=@work-rjkashyap/unified-ui",

--- a/packages/unified-ui/CHANGELOG.md
+++ b/packages/unified-ui/CHANGELOG.md
@@ -6,15 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [0.3.7] — 2026-03-15
 
 ### 🐛 Bug Fixes
 
-- **build:** Append .mjs/.cjs extensions to relative imports in post-build (#26) ([#26](https://github.com/imrj05/unified-ui/issues/26)) ([097be6d](https://github.com/imrj05/unified-ui/commit/097be6d1f65ab2a1333f87275a20485f696b3cac))
+- **package:** Update version to 0.3.7 and adjust dependencies ([f9da07a](https://github.com/imrj05/unified-ui/commit/f9da07a65a9756ac9f46cb4eb5e975209862baf1))
+- **build:** Resolve all package resolution errors — extensions, exports map, peer deps (v0.3.8) (#26)
+* fix(build): append .mjs/.cjs extensions to relative imports in post-build (#26)
+
+  * Bump @work-rjkashyap/unified-ui to v0.3.6
+
+  * Update unified-ui CHANGELOG for 0.3.5
+
+  * fix(exports): point sub-entry exports to subdirectory index files
+
+  With bundle:false, tsup emits each layer as a directory:
+    dist/theme/index.mjs   (not dist/theme.mjs)
+    dist/components/index.mjs  (not dist/components.mjs)
+    ...etc
+
+  The exports map and typesVersions both referenced the flat non-existent
+  paths, causing 'Module not found: Can't resolve @work-rjkashyap/unified-ui/theme'
+  (and /components, /tokens, /primitives, /motion, /utils). ([#26](https://github.com/imrj05/unified-ui/issues/26), [#26](https://github.com/imrj05/unified-ui/issues/26)) ([323fbda](https://github.com/imrj05/unified-ui/commit/323fbda5fd8fa0b062a6e6e9c9ec0e3f8e8525a2))
+## [0.3.6] — 2026-03-15
+
+### 🐛 Bug Fixes
+
+- **build:** Append .mjs/.cjs extensions to relative imports in post-build (#26) ([#26](https://github.com/imrj05/unified-ui/issues/26)) ([35c1896](https://github.com/imrj05/unified-ui/commit/35c189622ee545065f762461387e59b2d8efc21e))
+- **build:** Append .mjs/.cjs extensions to relative imports in post-build
+With bundle:false and custom outExtension, esbuild emits extensionless
+  relative specifiers (e.g. require('./components/accordion') or
+  from './motion'). Node's CJS and ESM resolvers do not auto-resolve
+  non-.js extensions, causing MODULE_NOT_FOUND errors at runtime. ([e27a7a0](https://github.com/imrj05/unified-ui/commit/e27a7a0e692d8efef357643383681ba48d4c3aca))
 
 ### Other
 
-- Bump @work-rjkashyap/unified-ui to v0.3.6 ([cb2d748](https://github.com/imrj05/unified-ui/commit/cb2d748b2225d03c308d5f46afb1bdec6ca6057b))
+- Bump @work-rjkashyap/unified-ui to v0.3.6 ([b9c6dd3](https://github.com/imrj05/unified-ui/commit/b9c6dd3dd94b72cba5e615d809e0763a146615e9))
+- Bump @work-rjkashyap/unified-ui to v0.3.5 ([c2565ce](https://github.com/imrj05/unified-ui/commit/c2565cecfc431fe5e49fe27498bc1e2cada38c02))
 - Revert ".github/workflows: Migrate workflows to Blacksmith runners (#24)" (#25)
 
 This reverts commit 6a3be7318fe805253461737ab05f7792e97bf3ca. ([#24](https://github.com/imrj05/unified-ui/issues/24), [#25](https://github.com/imrj05/unified-ui/issues/25)) ([28bf45a](https://github.com/imrj05/unified-ui/commit/28bf45a0fb6fe70e0ad8d6252e9beabc931a38fa))

--- a/packages/unified-ui/package.json
+++ b/packages/unified-ui/package.json
@@ -134,6 +134,7 @@
     "build": "tsup",
     "build:watch": "tsup --watch",
     "dev": "tsup --watch",
+    "analyze": "ANALYZE=true tsup",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run clean && npm run build",
@@ -160,16 +161,6 @@
     "tree-shakeable"
   ],
   "peerDependencies": {
-    "react": ">=19.0.0",
-    "react-dom": ">=19.0.0",
-    "tailwindcss": ">=4.0.0",
-    "radix-ui": ">=1.0.0",
-    "class-variance-authority": ">=0.7.0",
-    "clsx": ">=2.0.0",
-    "tailwind-merge": ">=3.0.0",
-    "sonner": ">=2.0.0",
-    "vaul": ">=1.0.0",
-    "react-resizable-panels": ">=4.0.0",
     "@radix-ui/primitive": ">=1.0.0",
     "@radix-ui/react-compose-refs": ">=1.0.0",
     "@radix-ui/react-context": ">=1.0.0",
@@ -182,10 +173,20 @@
     "@radix-ui/react-tooltip": ">=1.0.0",
     "@radix-ui/react-use-callback-ref": ">=1.0.0",
     "@radix-ui/react-use-controllable-state": ">=1.0.0",
+    "@radix-ui/react-use-effect-event": ">=0.0.1",
     "@radix-ui/react-use-layout-effect": ">=1.0.0",
     "@radix-ui/react-use-size": ">=1.0.0",
-    "@radix-ui/react-use-effect-event": ">=0.0.1",
-    "@radix-ui/react-visually-hidden": ">=1.0.0"
+    "@radix-ui/react-visually-hidden": ">=1.0.0",
+    "class-variance-authority": ">=0.7.0",
+    "clsx": ">=2.0.0",
+    "radix-ui": ">=1.0.0",
+    "react": ">=19.0.0",
+    "react-dom": ">=19.0.0",
+    "react-resizable-panels": ">=4.0.0",
+    "sonner": ">=2.0.0",
+    "tailwind-merge": ">=3.0.0",
+    "tailwindcss": ">=4.0.0",
+    "vaul": ">=1.0.0"
   },
   "peerDependenciesMeta": {
     "tailwindcss": {
@@ -262,13 +263,13 @@
     }
   },
   "dependencies": {
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "radix-ui": "^1.4.3",
-    "react-resizable-panels": "^4.7.1",
-    "sonner": "^2.0.7",
-    "tailwind-merge": "^3.4.0",
-    "vaul": "^1.1.2"
+    "class-variance-authority": ">=0.7.0",
+    "clsx": ">=2.0.0",
+    "radix-ui": ">=1.0.0",
+    "react-resizable-panels": ">=4.0.0",
+    "sonner": ">=2.0.0",
+    "tailwind-merge": ">=3.0.0",
+    "vaul": ">=1.0.0"
   },
   "optionalDependencies": {
     "@tanstack/react-table": ">=8.0.0",
@@ -281,6 +282,7 @@
     "framer-motion": "^12.34.3",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "rollup-plugin-visualizer": "^7.0.1",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/packages/unified-ui/package.json
+++ b/packages/unified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@work-rjkashyap/unified-ui",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "A scalable, token-driven React design system with 75+ components, built with Tailwind CSS v4, Radix UI, and Framer Motion.",
   "author": "Rajeshwar Kashyap",
   "license": "MIT",

--- a/packages/unified-ui/tsup.config.ts
+++ b/packages/unified-ui/tsup.config.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 
 import { dirname, extname, join, relative } from "node:path";
+import { analyzeMetafile } from "esbuild";
 import { defineConfig } from "tsup";
 
 // ---------------------------------------------------------------------------
@@ -301,6 +302,8 @@ function patchUseClient(distDir: string) {
   console.log('✅ Patched "use client" directive into client module files');
 }
 
+const ANALYZE = process.env.ANALYZE === "true";
+
 export default defineConfig(() => {
   const srcDir = join(__dirname, "src");
   const distDir = join(__dirname, "dist");
@@ -357,6 +360,18 @@ export default defineConfig(() => {
       "vaul",
       "react-resizable-panels",
     ],
+    // -------------------------------------------------------------------------
+    // Bundle analysis — only active when ANALYZE=true (npm run analyze).
+    //
+    // tsup uses esbuild under the hood, not Rollup, so rollup-plugin-visualizer
+    // cannot be wired in as a plugin. Instead we use tsup's built-in
+    // `metafile: true` option which writes dist/metafile-esm.json and
+    // dist/metafile-cjs.json, then feed the ESM metafile into esbuild's own
+    // `analyzeMetafile` for a rich terminal report. The raw metafile JSON is
+    // also retained in dist/ so it can be uploaded to https://esbuild.github.io/analyze/
+    // for an interactive treemap visualisation.
+    // -------------------------------------------------------------------------
+    ...(ANALYZE ? { metafile: true } : {}),
     async onSuccess() {
       // Order matters:
       // 1. rewriteAliases — converts @unified-ui/* bare specifiers to relative
@@ -369,6 +384,27 @@ export default defineConfig(() => {
       rewriteAliases(distDir);
       rewriteExtensions(distDir);
       patchUseClient(distDir);
+
+      if (ANALYZE) {
+        // tsup writes metafile-esm.json when metafile:true is set.
+        const metaPath = join(distDir, "metafile-esm.json");
+        if (statSync(metaPath, { throwIfNoEntry: false })?.isFile()) {
+          const meta = readFileSync(metaPath, "utf-8");
+          // analyzeMetafile prints a human-readable breakdown of every module,
+          // its size, and what imported it — equivalent to webpack-bundle-analyzer
+          // but for esbuild output.
+          const report = await analyzeMetafile(meta, { verbose: false });
+          console.log("\n📊 Bundle analysis (ESM):\n");
+          console.log(report);
+          console.log(
+            "💡 For an interactive treemap upload dist/metafile-esm.json to:",
+          );
+          console.log("   https://esbuild.github.io/analyze/\n");
+        } else {
+          console.warn("⚠  ANALYZE=true but dist/metafile-esm.json not found.");
+        }
+      }
+
       console.log("✅ Build complete — modules preserved for tree-shaking");
     },
   };


### PR DESCRIPTION
## What

Adds a `ANALYZE=true` build mode to the design system package that generates a detailed bundle size report.

## Why

With `bundle: false` (tree-shaking preserveModules build), it's hard to see which components are large, what they import, and where bytes are going. This gives visibility without changing the production build at all.

## How it works

`rollup-plugin-visualizer` is a Rollup plugin and can't plug directly into tsup's esbuild pipeline. Instead:

1. **`metafile: true`** — tsup's built-in option, emits `dist/metafile-esm.json` (esbuild's JSON description of every module, import, and byte size)
2. **`esbuild.analyzeMetafile()`** — reads the metafile and prints a rich terminal report sorted by size
3. **`dist/metafile-esm.json`** — kept on disk so you can upload it to the interactive treemap at https://esbuild.github.io/analyze/

## Changes

| File | Change |
|---|---|
| `packages/unified-ui/package.json` | Add `rollup-plugin-visualizer` devDep + `analyze` script |
| `packages/unified-ui/tsup.config.ts` | Wire `ANALYZE` env flag into build + `onSuccess` |
| `package.json` (root) | Add `analyze:ds` convenience script |

## Usage

```sh
# From repo root
npm run analyze:ds

# From packages/unified-ui directly  
npm run analyze
```

### Terminal output (sample)
```
📊 Bundle analysis (ESM):

  dist/components/data-table.mjs    46.5kb  100.0%
   └ src/components/data-table.tsx  46.5kb   99.8%

  dist/theme/presets.mjs            36.9kb  100.0%
   └ src/theme/presets.ts           36.4kb   98.5%

  dist/components/sidebar.mjs       32.4kb  100.0%
   └ src/components/sidebar.tsx     31.8kb   98.3%
  ...

💡 For an interactive treemap upload dist/metafile-esm.json to:
   https://esbuild.github.io/analyze/
```

The production build (`npm run build:ds`) is **completely unchanged** — `ANALYZE` only activates when explicitly set.